### PR TITLE
User Custom Context Support

### DIFF
--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -15,18 +15,18 @@ fn main() -> anyhow::Result<()> {
     let mut repl = Repl::builder()
         .add("ok", command! {
             "Run a command that just succeeds",
-            () => || Ok(CommandStatus::Done)
+            () => |_: &()| Ok(CommandStatus::Done)
         })
         .add("error", command! {
             "Command with recoverable error handled by the REPL",
-            (text:String) => |text| {
+            (text:String) => |_: &(), text| {
                 may_throw(text)?;
                 Ok(CommandStatus::Done)
             },
         })
         .add("critical", command! {
             "Command returns a critical error that must be handled outside of REPL",
-            (text:String) => |text| {
+            (text:String) => |_: &(), text| {
                 // Short notation using the Critical trait
                 may_throw(text).into_critical()?;
                 // More explicitly it could be:
@@ -42,7 +42,7 @@ fn main() -> anyhow::Result<()> {
         })
         .add("roulette", command! {
             "Feeling lucky?",
-            () => || {
+            () => |_: &()| {
                 let ns = Instant::now().duration_since(start).as_nanos();
                 let cylinder = ns % 6;
                 match cylinder {

--- a/examples/from_str.rs
+++ b/examples/from_str.rs
@@ -8,7 +8,7 @@ fn main() -> anyhow::Result<()> {
     let mut repl = Repl::builder()
         .add("ls", command! {
             "List files in a directory",
-            (dir: PathBuf) => |dir: PathBuf| {
+            (dir: PathBuf) => |_: &(), dir: PathBuf| {
                 for entry in dir.read_dir()? {
                     println!("{}", entry?.path().to_string_lossy());
                 }
@@ -17,7 +17,7 @@ fn main() -> anyhow::Result<()> {
         })
         .add("ipaddr", command! {
             "Just parse and print the given IP address",
-            (ip: IpAddr) => |ip: IpAddr| {
+            (ip: IpAddr) => |_: &(), ip: IpAddr| {
                 println!("{}", ip);
                 Ok(CommandStatus::Done)
             }

--- a/examples/matryoshka.rs
+++ b/examples/matryoshka.rs
@@ -7,7 +7,7 @@ fn matryoshka(name: String) -> anyhow::Result<Repl<'static>> {
     let cloned_prompt = prompt.clone();  // need to move it into closure
     let new = command! {
         "Enter new repl",
-        (name:String) => |name: String| {
+        (name:String) => |_: &(), name: String| {
             let name = cloned_prompt.clone() + &name;
             let mut repl = matryoshka(name)?;
             repl.run()?;

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -5,14 +5,14 @@ fn main() -> anyhow::Result<()> {
     let mut repl = Repl::builder()
         .add("hello", command! {
             "Say hello",
-            (name: String) => |name| {
+            (name: String) => |_: &(), name| {
                 println!("Hello {}!", name);
                 Ok(CommandStatus::Done)
             }
         })
         .add("add", command! {
             "Add X to Y",
-            (X:i32, Y:i32) => |x, y| {
+            (X:i32, Y:i32) => |_: &(), x, y| {
                 println!("{} + {} = {}", x, y, x + y);
                 Ok(CommandStatus::Done)
             }

--- a/examples/mut_state.rs
+++ b/examples/mut_state.rs
@@ -11,7 +11,7 @@ fn main() -> anyhow::Result<()> {
         .text_width(60 as usize)
         .add("count", command! {
             "Count from X to Y",
-            (X:i32, Y:i32) => |x, y| {
+            (X:i32, Y:i32) => |_: &(), x, y| {
                 for i in x..=y {
                     print!(" {}", i);
                 }
@@ -21,14 +21,14 @@ fn main() -> anyhow::Result<()> {
         })
         .add("say", command! {
             "Say X",
-            (:f32) => |x| {
+            (:f32) => |_: &(), x| {
                 println!("x is equal to {}", x);
                 Ok(CommandStatus::Done)
             },
         })
         .add("outx", command! {
             "Use mutably outside var x. This command has a really long description so we need to wrap it somehow, it is interesting how actually the wrapping will be performed.",
-            () => || {
+            () => |_: &()| {
                 outside_x += "x";
                 println!("{}", outside_x);
                 Ok(CommandStatus::Done)
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
         .add("outy", easy_repl::Command {
             description: "Use mutably outside var y".into(),
             args_info: vec!["appended".into()],
-            handler: Box::new(|args| {
+            handler: Box::new(|_: &(), args| {
                 let validator = validator!(i32);
                 validator(args)?;
                 outside_y += args[0];

--- a/src/command.rs
+++ b/src/command.rs
@@ -27,6 +27,31 @@ pub struct Command<'a, Context = ()> {
     pub handler: Box<Handler<'a, Context>>,
 }
 
+/// Command equals when types equal
+impl<'a, Context> std::cmp::PartialEq for Command<'a, Context> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.args_info.len() != other.args_info.len() {
+            return false;
+        }
+
+        for i in 0..self.args_info.len() {
+            let my_arg = &self.args_info[i];
+            let other_arg = &other.args_info[i];
+
+            let my_type_str = my_arg.split(":").collect::<Vec<_>>()[1];
+            let other_type_str = other_arg.split(":").collect::<Vec<_>>()[1];
+
+            if my_type_str != other_type_str {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl<'a, Context> std::cmp::Eq for Command<'a, Context> {}
+
 /// Return status of a command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CommandStatus {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,14 @@
 //! let mut repl = Repl::builder()
 //!     .add("hello", command! {
 //!         "Say hello",
-//!         (name: String) => |name| {
+//!         (name: String) => |_ctx: &(), name| {
 //!             println!("Hello {}!", name);
 //!             Ok(CommandStatus::Done)
 //!         }
 //!     })
 //!     .add("add", command! {
 //!         "Add X to Y",
-//!         (X:i32, Y:i32) => |x, y| {
+//!         (X:i32, Y:i32) => |_ctx: &(), x, y| {
 //!             println!("{} + {} = {}", x, y, x + y);
 //!             Ok(CommandStatus::Done)
 //!         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -245,12 +245,11 @@ impl<'a> Repl<'a> {
                 let line = format!("  {:width$}  {}", sig, desc, width = width);
                 textwrap::fill(&line, &opts)
             })
-            .reduce(|mut out, next| {
+            .fold(String::new(), |mut out, next| {
                 out.push_str("\n");
                 out.push_str(&next);
                 out
             })
-            .unwrap()
     }
 
     /// Returns formatted help message.


### PR DESCRIPTION
Currently `easy-repl` is unable to insert user custom context. So between commands, there's no way to share internal status. This PR should allow such feature.